### PR TITLE
Fix bundle to work with latest JRE

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,11 +5,19 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: 'bundle.[contenthash].js',
     library: 'jre',
     libraryTarget: 'var'
   },
   plugins: [
+    // Needed to bypass the setTimeout
+    // used by EventEmitter
+    // Since we do NOT actually pass in a non-zero
+    // and we do not need things to execute on a separate thread
+    // we can just execute the method immediately
+    new webpack.DefinePlugin({
+      setTimeout: '(fn => fn())',
+    }),
     new webpack.EnvironmentPlugin({
       DEBUG: false,
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,16 @@
 const path = require('path');
 const webpack = require('webpack');
 
+let commitHash = require('child_process')
+  .execSync('git rev-parse --short HEAD')
+  .toString()
+  .replace(/(\r\n|\n|\r)/gm, "");
+
 module.exports = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.[contenthash].js',
+    filename: `bundle.${commitHash}.[contenthash].js`,
     library: 'jre',
     libraryTarget: 'var'
   },


### PR DESCRIPTION
### Context
The original bundle was generated using the JRE `2.3.6`. However, since then there have been several [changes](https://github.com/trmlabs/json-rules-engine/blob/master/CHANGELOG.md). 

The core issue is that the package updated it's eventemitter dependency to use `eventemitter2` which has a dependency on setTimeout. 

setTimeout is a `runTime` (e.g., browsers, node) feature, and not part of the core JS spec. Hence, it's not supported natively by Google execution environment. 

See [Slack](https://trmlabs.slack.com/archives/C020UT1UHGX/p1637108240029800)

### Solution
We simply substitute setTimeout with and IIFE (immediately executing function) that we define on our own. 

This works because in the context of JRE, we do not: (a) need a time delay, and (b) do not need to call to run in a background thread (unlike in a browser). 

In addition, to the basic fix, we now output the bundle name to include a `bundle.[githash].[contenthash].js` to make is easier to manage version and reproduce issues.

### Note
Since we are effectively using a new version of JRE (in-line with B2B), the response signature HAS changed. See [Loom](https://www.loom.com/share/2e5ca382848540fdbde531f23dc5df47)

### Validation
Ran bundle in BQ against sample script: 

```
CREATE TEMP FUNCTION myFunc()
  RETURNS STRING
  LANGUAGE js
  OPTIONS (
    library=[
      "gs://trm-javascript-json-rules-engine/bundle-test.js"
     ]
  )
  AS
r"""

return (async () => {
  try {
    const engine = new jre.Engine();
    engine.addRule({
      conditions: {
        any: [{
          all: [{
            fact: 'gameDuration',
            operator: 'equal',
            value: 40
          }, {
            fact: 'personalFoulCount',
            operator: 'greaterThanInclusive',
            value: 5
          }]
        }, {
          all: [{
            fact: 'gameDuration',
            operator: 'equal',
            value: 48
          }, {
            fact: 'personalFoulCount',
            operator: 'greaterThanInclusive',
            value: 6
          }]
        }]
      },
      event: {  // define the event to fire when the conditions evaluate truthy
        type: 'fouledOut',
        params: {
          message: 'Player has fouled out!'
        }
      }
    });

/**
 * Define facts the engine will use to evaluate the conditions above.
 * Facts may also be loaded asynchronously at runtime; see the advanced example below
 */
let facts = {
  personalFoulCount: 6,
  gameDuration: 40
}

let messages = ['ada'];

// Run the engine to evaluate
  const { events: res } = await engine.run(facts)
  
  // events.map(event => messages.push(event.params.message));
  
  // messages = await new Promise((resolve, reject) => resolve('cde'))
  return JSON.stringify(res);
  } catch (error) {
    console.log(error);
    return 'error' || JSON.stringify(error);
  }
})();
""";

SELECT myFunc();
```

